### PR TITLE
Bumped CS kill date to 2023

### DIFF
--- a/.env
+++ b/.env
@@ -3,6 +3,6 @@ C2_IP=172.19.0.5
 C2_DOMAIN=domain.com
 C2_PASSWORD=password123
 C2_PROFILE=domain.profile
-KILLDATE=2022-12-30
+KILLDATE=2023-12-30
 KEYSTORE=domain.com.store
 PAYLOAD_DIR=/something/another


### PR DESCRIPTION
Bumped default Cobalt Strike kill date to 2023-12-30 to ensure that default setup provides a readily usable team server configuration.